### PR TITLE
Pete/improve interface generation

### DIFF
--- a/dts-generator/src/main/java/com/telerik/Main.java
+++ b/dts-generator/src/main/java/com/telerik/Main.java
@@ -16,7 +16,13 @@ public class Main {
 	public static void main(String[] args) throws Exception {
 		InputParameters inputParameters = parseCommand(args);
 
+		long startTime = System.currentTimeMillis();
+
 		new Generator().start(inputParameters);
+
+		long stopTime = System.currentTimeMillis();
+		long elapsedTime = stopTime - startTime;
+		System.out.println("Generation of definitions took " + elapsedTime + "ms.");
 	}
 
 	public static InputParameters parseCommand(String[] args) {


### PR DESCRIPTION
Interfaces now have constructors hinting at all the methods that need to be implemented. As per #2 
Interfaces and Classes now properly inherit fields and methods from interfaces they implement.

Abstract classes are now `abstract` -> `export abstract class A extends java.lang.Object ...`

Tested with `android sdk 23` jar

@Plamen5kov 
