### PR TITLE
Prevent NPE and report missing dependency instead

### DIFF
--- a/dts-generator/src/main/java/com/telerik/dts/DtsApi.java
+++ b/dts-generator/src/main/java/com/telerik/dts/DtsApi.java
@@ -349,6 +349,13 @@ public class DtsApi {
         String[] interfaceNames = classInterface.getInterfaceNames();
         for (String intface : interfaceNames) {
             JavaClass clazz1 = ClassRepo.findClass(intface);
+
+            // Added guard to prevent NullPointerExceptions in case libs are not provided - the dev can choose to include it and rerun the generator
+            if (clazz1 == null) {
+                System.out.println("ignoring definitions in missing dependency: " + intface);
+                continue;
+            }
+
             String className = clazz1.getClassName();
 
             // TODO: Pete: Hardcoded until we figure out how to go around the 'type incompatible with Object' issue


### PR DESCRIPTION
While generating d.ts files for the Mapbox SDK I ran into a NullPointerException I couldn't make sense of until I debugged the generator.

It turned out I had to provide numerous dependencies to make it work, but I didn't want those to be part of the resulting d.ts file.. 

So I've now made sure the generator doesn't choke on these and logs them to the console. If the developer cares about any of those missing classes he can lookup the related dependency (library) and rerun the generator.