### PR TITLE
Update DtsApi.java to filter `^` return signatures

### DIFF
--- a/dts-generator/src/main/java/com/telerik/dts/DtsApi.java
+++ b/dts-generator/src/main/java/com/telerik/dts/DtsApi.java
@@ -61,6 +61,7 @@ public class DtsApi {
     private boolean allGenericImplements;
     private Pattern methodSignature = Pattern.compile("\\((?<ArgumentsSignature>.*)\\)(?<ReturnSignature>.*)");
     private Pattern isWordPattern = Pattern.compile("^[\\w\\d]+$");
+    private Pattern isVoid = Pattern.compile("V(\\^.*\\;)?");
 
     public DtsApi(boolean allGenericImplements) {
         this.allGenericImplements = allGenericImplements;
@@ -757,7 +758,7 @@ public class DtsApi {
             Matcher matcher = methodSignature.matcher(signature.getSignature());
             if(matcher.matches()) {
                 String returnSignature = matcher.group(2);
-                if(returnSignature.equals("V") || returnSignature.contains("^")){
+                if(isVoid.matcher(returnSignature).matches()){
                     return m.getReturnType(); // returning void
                 }
                 return GenericUtilities.getType(returnSignature);

--- a/dts-generator/src/main/java/com/telerik/dts/DtsApi.java
+++ b/dts-generator/src/main/java/com/telerik/dts/DtsApi.java
@@ -757,7 +757,7 @@ public class DtsApi {
             Matcher matcher = methodSignature.matcher(signature.getSignature());
             if(matcher.matches()) {
                 String returnSignature = matcher.group(2);
-                if(returnSignature.equals("V")){
+                if(returnSignature.equals("V") || returnSignature.contains("^")){
                     return m.getReturnType(); // returning void
                 }
                 return GenericUtilities.getType(returnSignature);


### PR DESCRIPTION
Currently when I tried to run this against `com.google.android.exoplayer:exoplayer:+` the following error occurs:
```
java.lang.IllegalStateException: Invalid method signature: '(V^TE;)V' : V^TE;)V 
	at edu.umd.cs.findbugs.ba.generic.GenericSignatureParser$ParameterSignatureIterator.next(GenericSignatureParser.java:119)
	at edu.umd.cs.findbugs.ba.generic.GenericSignatureParser$ParameterSignatureIterator.next(GenericSignatureParser.java:45)
	at edu.umd.cs.findbugs.ba.generic.GenericSignatureParser.getNumParameters(GenericSignatureParser.java:184)
	at edu.umd.cs.findbugs.ba.generic.GenericUtilities.getType(GenericUtilities.java:263)
	at com.telerik.dts.DtsApi.getReturnType(DtsApi.java:768)
	at com.telerik.dts.DtsApi.generateInterfaceConstructorContent(DtsApi.java:513)
	at com.telerik.dts.DtsApi.processInterfaceConstructor(DtsApi.java:501)
	at com.telerik.dts.DtsApi.generateDtsContent(DtsApi.java:139)
	at com.telerik.dts.Generator.generateDts(Generator.java:57)
	at com.telerik.dts.Generator.start(Generator.java:42)
	at com.telerik.Main.main(Main.java:37)
Exception in thread "main" java.lang.NullPointerException
	at com.telerik.dts.DtsApi.getReturnType(DtsApi.java:769)
	at com.telerik.dts.DtsApi.generateInterfaceConstructorContent(DtsApi.java:513)
	at com.telerik.dts.DtsApi.processInterfaceConstructor(DtsApi.java:501)
	at com.telerik.dts.DtsApi.generateDtsContent(DtsApi.java:139)
	at com.telerik.dts.Generator.generateDts(Generator.java:57)
	at com.telerik.dts.Generator.start(Generator.java:42)
	at com.telerik.Main.main(Main.java:37)
```
By adding a filter `returnSignature.contains("^")` the library is able to run successfully.