### PR TITLE
Add section: How to use? on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,14 @@ A tool that generates TypeScript declaration files (.d.ts) from Jars
 - [Gradle](https://docs.gradle.org/current/userguide/gradle_wrapper.html)
 - Built gradle wrapper. [Read more](https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:adding_wrapper)
 
-
 Generate definitions following any of the approaches described below. Once you have run any of commands, you can find the generated typings in `dts-generator/out` directory.
+
+## How to use?
+In order to use this utility, the first thing to do is download it.
+```shell
+git clone https://github.com/NativeScript/android-dts-generator.git
+cd android-dts-generator
+```
 ## Generate definitons for Android SDK
 ```shell
 cd dts-generator

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ In order to use this utility, the first thing to do is download it.
 git clone https://github.com/NativeScript/android-dts-generator.git
 cd android-dts-generator
 ```
+
 ## Generate definitons for Android SDK
 ```shell
 cd dts-generator


### PR DESCRIPTION
When I entered to use this tool I did not know if I had to download it, it was a NS plugin or something else. I think it would be clearer by adding this section.