### PR TITLE
fix: handle ambiguous fields that class with an inner class

### DIFF
--- a/dts-generator/src/main/java/com/telerik/dts/DtsApi.java
+++ b/dts-generator/src/main/java/com/telerik/dts/DtsApi.java
@@ -920,12 +920,38 @@ public class DtsApi {
 
         if (isPrivateGoogleApiMember(fieldName)) return;
 
+        //
+        // handle member names that conflict with an inner class. For example:
+        // 
+        // class OuterClass {
+        //   public static InnerClass: OuterClass.InnerClass;
+        // 
+        //   class InnerClass {}   
+        // }
+        //
+        // the static field on the OuterClass will have a field type of OuterClass$InnerClass
+        // which we can check for and skip writing the static field to the definitions
+        // since typescript cannot handle this scenario well.
+        //
+
+        // the name of the field eg. InnerClass
+        String name = f.getName();
+
+        // the type of the field eg. OuterClass$InnerClass
+        String fieldTypeString = this.getFieldType(f).toString();
+
+        // we check if the name matches OuterClass (which we are currently in) + "$" + InnerClass
+        if(fieldTypeString.equals(clazz.getClassName() + "$" + name)) {
+            return;
+        }
+
         String tabs = getTabs(this.indent + 1);
         sbContent.append(tabs + "public ");
         if (f.isStatic()) {
             sbContent.append("static ");
         }
-        sbContent.appendln(f.getName() + ": " + getTypeScriptTypeFromJavaType(this.getFieldType(f), typeDefinition) + ";");
+
+        sbContent.appendln(name + ": " + getTypeScriptTypeFromJavaType(this.getFieldType(f), typeDefinition) + ";");
     }
 
     private void addClassField(JavaClass clazz) {


### PR DESCRIPTION
Attempts to fix #24

Not all cases might be covered by this fix, but the most common ones should be handled.

```ts
export class Cast extends javalangObject {
  // this is removed after this change  
  // public static CastApi: Cast.CastApi;
}
export module Cast {
  export class CastApi extends javalangObject {}
}
```

