### PR TITLE
feat: const field value is now part of the typings

### DIFF
--- a/dts-generator/src/main/java/com/telerik/dts/DtsApi.java
+++ b/dts-generator/src/main/java/com/telerik/dts/DtsApi.java
@@ -992,7 +992,13 @@ public class DtsApi {
             name = "\"" + name + "\"";
         }
         
-        sbContent.appendln(name + ": " + getTypeScriptTypeFromJavaType(this.getFieldType(f), typeDefinition) + ";");
+        sbContent.append(name + ": " + getTypeScriptTypeFromJavaType(this.getFieldType(f), typeDefinition));
+        if (f.getConstantValue() != null) {
+            sbContent.appendln( " = " + f.getConstantValue() + ";");
+        } else {
+            sbContent.appendln(";");
+
+        }
     }
 
     private void addClassField(JavaClass clazz) {


### PR DESCRIPTION
This allows typings to have actuall value for const fields. Just like we do on iOS.
My hope is that it will allow tsc/webpack to include the const value instead of the android variable (like it is done on iOS) which will prevent many JNI calls