### PR TITLE
perf: make dts generation 60x faster by changing a regex

### DIFF
--- a/dts-generator/src/main/java/com/telerik/dts/DtsApi.java
+++ b/dts-generator/src/main/java/com/telerik/dts/DtsApi.java
@@ -295,20 +295,22 @@ public class DtsApi {
 
     private static String replaceNonGenericUsage(String content, String className, Integer occurencies, String javalangObject) {
         String result = content;
-        Pattern usedAsNonGenericPattern = Pattern.compile("(?<Prefix>[^a-zA-Z\\d\\s:]*)" + className.replace(".", "\\.") + "(?<Suffix>[^a-zA-Z\\d^\\.^\\$^\\<])");
+        Pattern usedAsNonGenericPattern = Pattern.compile(className.replace(".", "\\.") + "(?<Suffix>[^a-zA-Z\\d^\\.^\\$^\\<])");
         Matcher matcher = usedAsNonGenericPattern.matcher(result);
-        if(matcher.find()) {
-            List<String> arguments = new ArrayList<>();
-            for (int i = 0; i < occurencies; i++) {
-                arguments.add(javalangObject);
-            }
-            String classSuffix = "<" + String.join(",", arguments) + ">";
+        
+        if (!matcher.find())
+            return content;
 
-            System.out.println(String.format("Appending %s to occurrences of class %s without passed generic types", classSuffix, className));
-
-            String replaceString = String.format("$1%s%s$2", className, classSuffix);
-            result = matcher.replaceAll(replaceString);
+        List<String> arguments = new ArrayList<>();
+        for (int i = 0; i < occurencies; i++) {
+            arguments.add(javalangObject);
         }
+        String classSuffix = "<" + String.join(",", arguments) + ">";
+        
+        System.out.println(String.format("Appending %s to occurrences of class %s without passed generic types", classSuffix, className));
+
+        String replaceString = String.format("%s%s$1", className, classSuffix);
+        result = matcher.replaceAll(replaceString);
         return result;
     }
 


### PR DESCRIPTION
The `usedAsNonGenericPattern` has a "Prefix" group that is not used for anything and contains a `*` modifier that is too broad and backtracks **a lot**. This perf improvement simply removes this matching group and leaves only the "Suffix" group which does not contain any backtracking modifiers.

This little change improves the DTS generation time from over 240 seconds down to only 4 seconds on my machine

I have tested this change on Android APIs from 30 to 34 and it generates the exact same output.